### PR TITLE
eslint: define "no-unused-vars" for ES6 environments

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -53,6 +53,7 @@
   "no-unexpected-multiline": [],
   "no-unneeded-ternary": [{"defaultAssignment": false}],
   "no-unreachable": [],
+  "no-unused-vars": [{"vars": "all", "args": "none", "caughtErrors": "none"}],
   "no-useless-concat": [],
   "no-useless-escape": [],
   "no-whitespace-before-property": [],

--- a/eslint-es3-only.json
+++ b/eslint-es3-only.json
@@ -7,6 +7,5 @@
   "no-inner-declarations": ["functions"],
   "no-invalid-regexp": [{"allowConstructorFlags": ["g", "i", "m"]}],
   "no-redeclare": [{"builtinGlobals": true}],
-  "no-unused-vars": [{"vars": "all", "args": "none", "caughtErrors": "none"}],
   "quote-props": ["as-needed", {"keywords": true}]
 }

--- a/eslint-es6.json
+++ b/eslint-es6.json
@@ -63,6 +63,7 @@
     "no-unexpected-multiline": ["error"],
     "no-unneeded-ternary": ["error", {"defaultAssignment": false}],
     "no-unreachable": ["error"],
+    "no-unused-vars": ["error", {"args": "none", "caughtErrors": "none", "vars": "all"}],
     "no-useless-computed-key": ["error"],
     "no-useless-concat": ["error"],
     "no-useless-escape": ["error"],


### PR DESCRIPTION
Despite the name, [`no-unused-vars`][1] applies to `const` as well. :)


[1]: http://eslint.org/docs/rules/no-unused-vars
