### PR TITLE
eslint: define "space-before-blocks"

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -64,6 +64,7 @@
   "radix": ["always"],
   "semi": ["always", {"omitLastInOneLineBlock": false}],
   "semi-spacing": [{"before": false, "after": true}],
+  "space-before-blocks": ["always"],
   "space-before-function-paren": [{"anonymous": "never", "named": "never"}],
   "space-in-parens": ["never", {"exceptions": []}],
   "space-infix-ops": [],

--- a/eslint-es3.json
+++ b/eslint-es3.json
@@ -74,6 +74,7 @@
     "radix": ["error", "always"],
     "semi": ["error", "always", {"omitLastInOneLineBlock": false}],
     "semi-spacing": ["error", {"after": true, "before": false}],
+    "space-before-blocks": ["error", "always"],
     "space-before-function-paren": ["error", {"anonymous": "never", "named": "never"}],
     "space-in-parens": ["error", "never", {"exceptions": []}],
     "space-infix-ops": ["error"],

--- a/eslint-es6.json
+++ b/eslint-es6.json
@@ -82,6 +82,7 @@
     "radix": ["error", "always"],
     "semi": ["error", "always", {"omitLastInOneLineBlock": false}],
     "semi-spacing": ["error", {"after": true, "before": false}],
+    "space-before-blocks": ["error", "always"],
     "space-before-function-paren": ["error", {"anonymous": "never", "named": "never"}],
     "space-in-parens": ["error", "never", {"exceptions": []}],
     "space-infix-ops": ["error"],


### PR DESCRIPTION
[`space-before-blocks`][1] allows us to require a space between `)` and `{` in code such as this:

```javascript
if (checkTypes) {
  // ...
}
```


[1]: http://eslint.org/docs/rules/space-before-blocks
