### PR TITLE
eslint: disable "no-negated-condition" rule

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -40,7 +40,7 @@
     "no-mixed-spaces-and-tabs": ["error"],
     "no-multi-str": ["error"],
     "no-multiple-empty-lines": ["error", {"max": 2, "maxBOF": 0, "maxEOF": 0}],
-    "no-negated-condition": ["error"],
+    "no-negated-condition": ["off"],
     "no-new-object": ["error"],
     "no-octal": ["error"],
     "no-octal-escape": ["error"],

--- a/example-es3.js
+++ b/example-es3.js
@@ -57,13 +57,9 @@ baz = (function(baz) {
 }(baz));
 
 console.log(
-  baz === 'baz' ?
-    /x/.test(baz) ?
-      Math.sin :
-    // else
-      Math.cos :
-  // else
-    Math.abs
+  baz !== 'baz' ? Math.abs :
+  /x/.test(baz) ? Math.sin :
+  /* otherwise */ Math.cos
 );
 
 console.log(['foo',

--- a/example-es6.js
+++ b/example-es6.js
@@ -51,13 +51,9 @@ baz = (baz => {
 })(baz);
 
 console.log(
-  baz === 'baz' ?
-    /x/.test(baz) ?
-      Math.sin :
-    // else
-      Math.cos :
-  // else
-    Math.abs
+  baz !== 'baz' ? Math.abs :
+  /x/.test(baz) ? Math.sin :
+  /* otherwise */ Math.cos
 );
 
 console.log(['foo',


### PR DESCRIPTION
As the contrived example demonstrates, negating a condition can reduce nesting. I agree with much of the _Zen of Python_, including this principle:

```console
$ python -c 'import this' | grep nest
Flat is better than nested.
```
