### PR TITLE
eslint: allow unnecessary quoting of object property names

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -9,6 +9,7 @@
     "computed-property-spacing": ["error", "never"],
     "curly": ["error", "multi-line", "consistent"],
     "dot-location": ["error", "property"],
+    "dot-notation": ["off"],
     "eol-last": ["error", "always"],
     "eqeqeq": ["error", "always", {"null": "never"}],
     "for-direction": ["error"],
@@ -70,6 +71,7 @@
     "object-curly-spacing": ["error", "never"],
     "object-property-newline": ["error", {"allowMultiplePropertiesPerLine": true}],
     "operator-assignment": ["error", "always"],
+    "quote-props": ["error", "consistent"],
     "quotes": ["error", "single", {"avoidEscape": true}],
     "radix": ["error", "always"],
     "semi": ["error", "always", {"omitLastInOneLineBlock": false}],
@@ -95,17 +97,13 @@
     },
     {
       "files": ["karma.conf.js"],
-      "env": {"node": true},
-      "rules": {
-        "dot-notation": ["error", {"allowKeywords": true}]
-      }
+      "env": {"node": true}
     },
     {
       "files": ["test/**/*.js"],
       "env": {"es6": true, "node": true},
       "globals": {"suite": false, "test": false},
       "rules": {
-        "dot-notation": ["error", {"allowKeywords": true}],
         "max-len": ["off"]
       }
     }

--- a/eslint-es3.json
+++ b/eslint-es3.json
@@ -2,13 +2,11 @@
   "extends": ["./eslint-common.json"],
   "rules": {
     "comma-dangle": ["error", "never"],
-    "dot-notation": ["error", {"allowKeywords": false}],
     "func-style": ["error", "declaration", {"allowArrowFunctions": false}],
     "no-catch-shadow": ["error"],
     "no-func-assign": ["error"],
     "no-inner-declarations": ["error", "functions"],
     "no-invalid-regexp": ["error", {"allowConstructorFlags": ["g", "i", "m"]}],
-    "no-redeclare": ["error", {"builtinGlobals": true}],
-    "quote-props": ["error", "as-needed", {"keywords": true}]
+    "no-redeclare": ["error", {"builtinGlobals": true}]
   }
 }

--- a/eslint-es6.json
+++ b/eslint-es6.json
@@ -6,7 +6,6 @@
     "arrow-parens": ["error", "as-needed"],
     "arrow-spacing": ["error", {"before": true, "after": true}],
     "comma-dangle": ["error", "always-multiline"],
-    "dot-notation": ["error", {"allowKeywords": true}],
     "func-style": ["error", "declaration", {"allowArrowFunctions": true}],
     "generator-star-spacing": ["error", {"before": false, "after": true}],
     "no-const-assign": ["error"],
@@ -20,7 +19,6 @@
     "prefer-rest-params": ["error"],
     "prefer-spread": ["error"],
     "prefer-template": ["error"],
-    "quote-props": ["error", "as-needed", {"keywords": false}],
     "template-curly-spacing": ["error", "never"],
     "template-tag-spacing": ["error", "never"],
     "yield-star-spacing": ["error", {"before": false, "after": true}]

--- a/example-es3.js
+++ b/example-es3.js
@@ -71,13 +71,13 @@ console.log({foo: 1,
              baz: 3});
 
 console.log({
-  abc: 0,
+  'abc': 0,
   'var': 0,
-  xyz: 0
+  'xyz': 0
 });
 
 var rules = {
-  semi: [
+  'semi': [
     'error',
     'always',
     {omitLastInOneLineBlock: false}
@@ -92,6 +92,6 @@ var rules = {
   ]
 };
 
-console.log(rules.semi);
+console.log(rules['semi']);
 console.log(rules['semi-spacing']);
 console.log(rules['semi-style']);

--- a/example-es6.js
+++ b/example-es6.js
@@ -71,7 +71,7 @@ console.log({
 });
 
 const rules = {
-  semi: [
+  'semi': [
     'error',
     'always',
     {omitLastInOneLineBlock: false},
@@ -86,6 +86,6 @@ const rules = {
   ],
 };
 
-console.log(rules.semi);
+console.log(rules['semi']);
 console.log(rules['semi-spacing']);
 console.log(rules['semi-style']);


### PR DESCRIPTION
Unnecessary quoting is sometimes justified, as this diff demonstrates:

```diff
-console.log(rules.semi);
+console.log(rules['semi']);
 console.log(rules['semi-spacing']);
 console.log(rules['semi-style']);
```

An added benefit of this change is increased compatibility with the Closure Compiler.
