### PR TITLE
eslint: move "computed-property-spacing" rule

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -6,7 +6,6 @@
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-spacing": ["error", {"before": false, "after": true}],
     "comma-style": ["error", "last"],
-    "computed-property-spacing": ["error", "never"],
     "curly": ["error", "multi-line", "consistent"],
     "dot-location": ["error", "property"],
     "dot-notation": ["off"],

--- a/eslint-es6.json
+++ b/eslint-es6.json
@@ -6,6 +6,7 @@
     "arrow-parens": ["error", "as-needed"],
     "arrow-spacing": ["error", {"before": true, "after": true}],
     "comma-dangle": ["error", "always-multiline"],
+    "computed-property-spacing": ["error", "never"],
     "func-style": ["error", "declaration", {"allowArrowFunctions": true}],
     "generator-star-spacing": ["error", {"before": false, "after": true}],
     "no-const-assign": ["error"],


### PR DESCRIPTION
Computed properties were added in ES6, so this rule rightly belongs in __eslint-es6.json__.
