### PR TITLE
eslint: make allowances for doctests

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -91,8 +91,18 @@
   },
   "overrides": [
     {
+      "files": ["*.md"],
+      "plugins": ["markdown"],
+      "env": {"es6": true, "node": true},
+      "rules": {
+        "array-bracket-spacing": ["off"],
+        "func-style": ["error", "declaration", {"allowArrowFunctions": true}],
+        "strict": ["off"]
+      }
+    },
+    {
       "files": ["index.js"],
-      "globals": {"define": false, "module": false, "require": false, "self": false}
+      "globals": {"__doctest": false, "define": false, "module": false, "require": false, "self": false}
     },
     {
       "files": ["karma.conf.js"],


### PR DESCRIPTION
This pull request will reduce the amount of configuration required to (successfully) lint doctests.
