### PR TITLE
eslint: disable "prefer-template" rule

### DIFF
--- a/eslint-es6.json
+++ b/eslint-es6.json
@@ -19,7 +19,7 @@
     "prefer-numeric-literals": ["error"],
     "prefer-rest-params": ["error"],
     "prefer-spread": ["error"],
-    "prefer-template": ["error"],
+    "prefer-template": ["off"],
     "template-curly-spacing": ["error", "never"],
     "template-tag-spacing": ["error", "never"],
     "yield-star-spacing": ["error", {"before": false, "after": true}]


### PR DESCRIPTION
I have found the `prefer-template` rule to be overly prescriptive, and have disabled it in several projects. I see the appeal of a consistent approach to string concatenation, but template literals are significantly noisier in some cases. Consider the following examples:

```javascript
`${x}${y}`
`${x} ${y}`
`${f (x)}${f (y)}`
`${f (x)} ${f (y)}`
```

The equivalent expressions without template literals read better:

```javascript
x + y
x + ' ' + y
f (x) + f (y)
f (x) + ' ' + f (y)
```

In some cases, of course, template literals are the better option. By disabling the `prefer-template` rule we allow authors to exercise their judgement.
