### PR TITLE
eslint@5.1.x

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -2,6 +2,7 @@
   "rules": {
     "array-bracket-newline": ["error", "consistent"],
     "array-bracket-spacing": ["error", "never"],
+    "array-element-newline": ["error", "consistent"],
     "block-spacing": ["error", "always"],
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}],
     "comma-spacing": ["error", {"before": false, "after": true}],
@@ -18,6 +19,7 @@
     "keyword-spacing": ["error", {"before": true, "after": true}],
     "linebreak-style": ["error", "unix"],
     "max-len": ["error", {"code": 79, "ignoreUrls": true, "ignorePattern": "^ *//(# |  .* :: |[.] > |[.] // )"}],
+    "multiline-comment-style": ["error", "separate-lines"],
     "new-parens": ["error"],
     "no-array-constructor": ["error"],
     "no-caller": ["error"],

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "eslint": "4.9.x",
+    "eslint": "5.1.x",
     "xyz": "3.0.x"
   },
   "peerDependencies": {
-    "eslint": "4.9.x"
+    "eslint": "5.1.x"
   },
   "files": [
     "/LICENSE",


### PR DESCRIPTION
  - <https://eslint.org/blog/2018/06/eslint-v5.0.0-released>
  - <https://eslint.org/docs/user-guide/migrating-to-5.0.0>
