### PR TITLE
eslint: tweak "max-len" rule to accommodate wrapped doctests

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -18,7 +18,7 @@
     "key-spacing": ["error", {"beforeColon": false, "afterColon": true, "mode": "strict"}],
     "keyword-spacing": ["error", {"before": true, "after": true}],
     "linebreak-style": ["error", "unix"],
-    "max-len": ["error", {"code": 79, "ignoreUrls": true, "ignorePattern": "^ *//(# |  .* :: |[.] > |[.] // )"}],
+    "max-len": ["error", {"code": 79, "ignoreUrls": true, "ignorePattern": "^ *//(# |  .* :: |[.] [>.] |[.] // )"}],
     "multiline-comment-style": ["error", "separate-lines"],
     "new-parens": ["error"],
     "no-array-constructor": ["error"],


### PR DESCRIPTION
We already make an exception to the `max-len` rule for lines beginning with `//. > ` (doctest input lines).

This pull request adds an exception for lines beginning with `//. . ` (wrapped doctest input or output).
