### PR TITLE
eslint: use "readonly" for globals in place of deprecated value

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -111,7 +111,7 @@
     },
     {
       "files": ["index.js"],
-      "globals": {"__doctest": false, "define": false, "module": false, "require": false, "self": false}
+      "globals": {"__doctest": "readonly", "define": "readonly", "module": "readonly", "require": "readonly", "self": "readonly"}
     },
     {
       "files": ["karma.conf.{js,mjs}"],
@@ -120,7 +120,7 @@
     {
       "files": ["test/**/*.{js,mjs}"],
       "env": {"es6": true, "node": true},
-      "globals": {"suite": false, "test": false},
+      "globals": {"suite": "readonly", "test": "readonly"},
       "rules": {
         "max-len": ["off"]
       }


### PR DESCRIPTION
[Specifying Globals][1]:

> To configure global variables inside of a configuration file, set the `globals` configuration property to an object containing keys named for each of the global variables you want to use. For each global variable key, set the corresponding value equal to `"writable"` to allow the variable to be overwritten or `"readonly"` to disallow overwriting.

> For historical reasons, the boolean value `false` and the string value `"readable"` are equivalent to `"readonly"`. Similarly, the boolean value `true` and the string value `"writeable"` are equivalent to `"writable"`. However, the use of older values is deprecated.


[1]: https://eslint.org/docs/user-guide/configuring/language-options#specifying-globals
