### PR TITLE
eslint: remove override for Karma configuration files

### DIFF
--- a/eslint-common.json
+++ b/eslint-common.json
@@ -114,10 +114,6 @@
       "globals": {"__doctest": "readonly", "define": "readonly", "module": "readonly", "require": "readonly", "self": "readonly"}
     },
     {
-      "files": ["karma.conf.{js,mjs}"],
-      "env": {"node": true}
-    },
-    {
       "files": ["test/**/*.{js,mjs}"],
       "env": {"es6": true, "node": true},
       "globals": {"suite": "readonly", "test": "readonly"},


### PR DESCRIPTION
[Karma][1] is not currently used to test any Sanctuary project. In any case, this override feels too specific to be included here.


[1]: https://karma-runner.github.io/
