### PR TITLE
eslint: tweak "comma-dangle" rule to accommodate curried functions

### DIFF
--- a/eslint-es6.json
+++ b/eslint-es6.json
@@ -5,7 +5,7 @@
     "arrow-body-style": ["error", "as-needed"],
     "arrow-parens": ["error", "as-needed"],
     "arrow-spacing": ["error", {"before": true, "after": true}],
-    "comma-dangle": ["error", "always-multiline"],
+    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline", "imports": "always-multiline", "exports": "always-multiline", "functions": "never"}],
     "computed-property-spacing": ["error", "never"],
     "func-style": ["error", "declaration", {"allowArrowFunctions": true}],
     "generator-star-spacing": ["error", {"before": false, "after": true}],


### PR DESCRIPTION
Reducing diff noise is one of the goals of this project. Trailing commas play a significant role. For example:

```diff
 const tokens = [
   'foo',
   'bar',
   'baz',
+  'quux',
 ];
```

In the Sanctuary world we only ever define curried functions. Functions are almost always applied to exactly one argument. Trailing commas are unhelpful in this context. For example:

```javascript
return foo (
  bar (baz)
      (quux),
);
```

Unless `foo` is a “foreign” function it will never be applied to more than one argument; the trailing comma does not provide a potential benefit to future diffs.

This pull request tweaks the [`comma-dangle`][1] rule to prohibit rather than require a trailing comma after a function argument not immediately followed by a `)`.


[1]: https://eslint.org/docs/rules/comma-dangle
