### PR TITLE
disable `multiline-comment-style` rule

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -28,7 +28,7 @@
     "keyword-spacing": ["error", {"before": true, "after": true}],
     "linebreak-style": ["error", "unix"],
     "max-len": ["error", {"code": 79, "ignoreUrls": true, "ignorePattern": "^ *//(# |  .* :: |[.] [>.] |[.] // )"}],
-    "multiline-comment-style": ["error", "separate-lines"],
+    "multiline-comment-style": ["off"],
     "new-parens": ["error"],
     "no-array-constructor": ["error"],
     "no-caller": ["error"],


### PR DESCRIPTION
There are valid reasons to use `/* ... */` comments even in codebases that generally use `//` comments.

We currently disable [`multiline-comment-style`][1] in many places:

```console
$ fgrep -l '"multiline-comment-style": ["off"]' **/.eslintrc.json
sanctuary-def/.eslintrc.json
sanctuary-descending/.eslintrc.json
sanctuary-either/.eslintrc.json
sanctuary-identity/.eslintrc.json
sanctuary-maybe/.eslintrc.json
sanctuary-pair/.eslintrc.json
sanctuary-type-classes/.eslintrc.json
sanctuary-type-identifiers/.eslintrc.json
sanctuary/.eslintrc.json
```

We want a style *guide* rather than style *rules*.


[1]: https://eslint.org/docs/latest/rules/multiline-comment-style
